### PR TITLE
Fix interpretation of ucPhasePartialFourier for values >4/8ths

### DIFF
--- a/parameter_maps/IsmrmrdParameterMap.xsl
+++ b/parameter_maps/IsmrmrdParameterMap.xsl
@@ -22,8 +22,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:variable name="partialFourierPhase">
   <xsl:choose>
 	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 1">0.5</xsl:when>
-	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.75</xsl:when>
-	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.875</xsl:when>
+	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.625</xsl:when>
+	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 4">0.75</xsl:when>
+	<xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 8">0.875</xsl:when>
 	<xsl:otherwise>1.0</xsl:otherwise>
   </xsl:choose>
 </xsl:variable>

--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
@@ -26,8 +26,9 @@
     <xsl:variable name="partialFourierPhase">
         <xsl:choose>
             <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 1">0.5</xsl:when>
-            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.75</xsl:when>
-            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 4">0.875</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.625</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 4">0.75</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 8">0.875</xsl:when>
             <xsl:otherwise>1.0</xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/parameter_maps/IsmrmrdParameterMap_Siemens_EPI.xsl
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens_EPI.xsl
@@ -26,8 +26,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:variable name="partialFourierPhase">
         <xsl:choose>
             <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 1">0.5</xsl:when>
-            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.75</xsl:when>
-            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 4">0.875</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 2">0.625</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 4">0.75</xsl:when>
+            <xsl:when test="siemens/MEAS/sKSpace/ucPhasePartialFourier = 8">0.875</xsl:when>
             <xsl:otherwise>1.0</xsl:otherwise>
         </xsl:choose>
     </xsl:variable>


### PR DESCRIPTION
I believe the interpretation of the ucPhasePartialFourier enum is missing the case for 5/8ths, which is enumed as 2.  This resulted in partial Fourier factors of 5/8ths being interpreted as 6/8ths, 6/8ths being interpreted as 7/8ths, and 7/8ths being interpreted as no partial Fourier.