### PR TITLE
following the ismrmrd definition, for MSCV, stdint may not be available

### DIFF
--- a/siemensraw.h
+++ b/siemensraw.h
@@ -1,11 +1,25 @@
 #ifndef SIEMENSRAW_H_
 #define SIEMENSRAW_H_
 
-#include <stdint.h>
 #include <iostream>
 #include <fstream>
 #include <map>
 #include <string>
+
+#ifdef _MSC_VER /* MS compiler */
+    #ifndef HAS_INT_TYPE
+        typedef __int8 int8_t;
+        typedef unsigned __int8 uint8_t;
+        typedef __int16 int16_t;
+        typedef unsigned __int16 uint16_t;
+        typedef __int32 int32_t;
+        typedef unsigned __int32 uint32_t;
+        typedef __int64 int64_t;
+        typedef unsigned __int64 uint64_t;
+    #endif
+#else /* non MS C or C++ compiler */
+    #include <stdint.h>
+#endif /* _MSC_VER */
 
 #define MDH_NUMBEROFEVALINFOMASK   2
 

--- a/siemensraw.h
+++ b/siemensraw.h
@@ -6,16 +6,18 @@
 #include <map>
 #include <string>
 
-#ifdef _MSC_VER /* MS compiler */
+#if _MSC_VER < 1700 /* MS compiler */
     #ifndef HAS_INT_TYPE
-        typedef __int8 int8_t;
-        typedef unsigned __int8 uint8_t;
-        typedef __int16 int16_t;
-        typedef unsigned __int16 uint16_t;
-        typedef __int32 int32_t;
-        typedef unsigned __int32 uint32_t;
-        typedef __int64 int64_t;
-        typedef unsigned __int64 uint64_t;
+        #ifndef _STDINT
+            typedef signed char        int8_t;
+            typedef short              int16_t;
+            typedef int                int32_t;
+            typedef long long          int64_t;
+            typedef unsigned char      uint8_t;
+            typedef unsigned short     uint16_t;
+            typedef unsigned int       uint32_t;
+            typedef unsigned long long uint64_t;
+        #endif // _STDINT
     #endif
 #else /* non MS C or C++ compiler */
     #include <stdint.h>


### PR DESCRIPTION
The stdint.h is not always available for MSVC

Following the procedure used in line 24-34 of ismrmrd.h, the converter part is changed accordingly.

in ismrmrd.h:

![image](https://cloud.githubusercontent.com/assets/7012710/24336682/8be4b4a6-1261-11e7-98c4-ba7b06c954c4.png)
