### PR TITLE
add search CMAK_PREFIX_PATH, this allows to find ismrmrd in non-syste…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,21 @@ cmake_minimum_required(VERSION 2.6)
 
 project(SIEMENS-TO-ISMRMRD)
 
+# --- Provide good defaults for searching for packages (i.e. ismrmrd)
+set(CMAKE_PREFIX_PATH "")
+if(CMAKE_PREFIX_PATH)
+  list(APPEND CMAKE_PREFIX_PATH "/usr/local")
+endif()
+if(EXISTS $ENV{CMAKE_PREFIX_PATH})
+  list(APPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+endif()
+if(EXISTS $ENV{ISMRMRD_HOME})
+  list(APPEND CMAKE_PREFIX_PATH $ENV{ISMRMRD_HOME})
+endif()
+list(REMOVE_DUPLICATES CMAKE_PREFIX_PATH)
+message(STATUS "Looking for packages in : ${CMAKE_PREFIX_PATH}")
+# ---
+
 #VERSIONING
 set(SIEMENS_TO_ISMRMRD_VERSION_MAJOR 1)
 set(SIEMENS_TO_ISMRMRD_VERSION_MINOR 0)


### PR DESCRIPTION
Add search for CMAKE_PREFIX_PATH. So the siemens_to_ismrmrd can find ismrmrd installed at non-standard places.