### PR TITLE
Account for table offset in image position

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -81,7 +81,7 @@ std::vector<MeasurementHeaderBuffer> readMeasurementHeaderBuffers(std::ifstream 
 
 std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_content, uint32_t num_buffers,
                           std::vector<MeasurementHeaderBuffer> &buffers, std::vector<std::string> &wip_double,
-                          Trajectory &trajectory, long &dwell_time_0, long &max_channels, long &radial_views,
+                          Trajectory &trajectory, long &dwell_time_0, long &max_channels, long &radial_views, long* global_table_pos,
                           std::string &baseLineString, std::string &protocol_name);
 
 std::string parseXML(bool debug_xml, const std::string &parammap_xsl_content, std::string &schema_file_name_content,
@@ -93,7 +93,7 @@ ISMRMRD::NDArray<float>
 
 
 ISMRMRD::Acquisition
-        getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell_time_0, long max_channels,
+        getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell_time_0, long* global_table_pos, long max_channels,
                        bool isAdjustCoilSens, bool isAdjQuietCoilSens, bool isVB, ISMRMRD::NDArray<float> &traj,
                        const sScanHeader &scanhead, const std::vector<ChannelHeaderAndData> &channels);
 
@@ -711,11 +711,11 @@ int main(int argc, char *argv[] )
     long dwell_time_0;
     long max_channels;
     long radial_views;
-    long* global_table_pos;
+    long* global_table_pos = new long [3];
     std::string baseLineString;
     std::string protocol_name;
     std::string xml_config = readXmlConfig(debug_xml, parammap_file_content, num_buffers, buffers, wip_double, trajectory, dwell_time_0,
-                                           max_channels, radial_views, global_table_pos, baseLineString, protocol_name);
+                                          max_channels, radial_views, global_table_pos, baseLineString, protocol_name);
 
     // whether this scan is a adjustment scan
     bool isAdjustCoilSens = false;
@@ -881,6 +881,7 @@ int main(int argc, char *argv[] )
                                                           isAdjQuietCoilSens, isVB, traj, scanhead, channels));
 
     }//End of the while loop
+    delete [] global_table_pos;
 
     if (!siemens_dat)
     {
@@ -1037,9 +1038,9 @@ getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell
     }
     // std::cout << "ismrmrd_acq.sample_time_us(): " << ismrmrd_acq.sample_time_us() << std::endl;
 
-    ismrmrd_acq.position()[0] = scanhead.sSliceData.sSlicePosVec.flSag + global_table_pos[0];
-    ismrmrd_acq.position()[1] = scanhead.sSliceData.sSlicePosVec.flCor + global_table_pos[1];
-    ismrmrd_acq.position()[2] = scanhead.sSliceData.sSlicePosVec.flTra + global_table_pos[2];
+    ismrmrd_acq.position()[0] = scanhead.sSliceData.sSlicePosVec.flSag + (float) (global_table_pos[0]);
+    ismrmrd_acq.position()[1] = scanhead.sSliceData.sSlicePosVec.flCor + (float) (global_table_pos[1]);
+    ismrmrd_acq.position()[2] = scanhead.sSliceData.sSlicePosVec.flTra + (float) (global_table_pos[2]);
 
     // Convert Siemens quaternions to direction cosines.
     // In the Siemens convention the quaternion corresponds to a rotation matrix with columns P R S
@@ -1581,7 +1582,6 @@ std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_conte
     dwell_time_0= 0;
     max_channels= 0;
     radial_views= 0;
-    global_table_pos = new long [3];
     protocol_name= "";
     std::vector<std::string> wip_long;
     long center_line = 0;
@@ -1918,7 +1918,6 @@ std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_conte
                     radial_views = atoi(temp[0].c_str());
                 }
             }
-
             //Get some parameters - global table position
             {
                 const XProtocol::XNode* n2 = apply_visitor(XProtocol::getChildNodeByName("DICOM.lGlobalTablePosSag"), n);
@@ -1931,14 +1930,14 @@ std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_conte
                     }
                     else
                     {
-                        global_table_pos[0] = atoi(temp[0].c_str());
+                        global_table_pos[0] = atol(temp[0].c_str());
                     }
                 }
                 else {
                     std::cout << "DICOM.lGlobalTablePosSag not found" << std::endl;
                     global_table_pos[0] = 0;
                 }
-                
+
                 n2 = apply_visitor(XProtocol::getChildNodeByName("DICOM.lGlobalTablePosCor"), n);
                 if (n2) {
                     temp = apply_visitor(XProtocol::getStringValueArray(), *n2);
@@ -1948,14 +1947,14 @@ std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_conte
                     }
                     else
                     {
-                        global_table_pos[1] = atoi(temp[0].c_str());
+                        global_table_pos[1] = atol(temp[0].c_str());
                     }
                 }
                 else {
                     std::cout << "DICOM.lGlobalTablePosCor not found" << std::endl;
                     global_table_pos[1] = 0;
                 }
-                
+
                 n2 = apply_visitor(XProtocol::getChildNodeByName("DICOM.lGlobalTablePosTra"), n);
                 if (n2) {
                     temp = apply_visitor(XProtocol::getStringValueArray(), *n2);
@@ -1965,13 +1964,13 @@ std::string readXmlConfig(bool debug_xml, const std::string &parammap_file_conte
                     }
                     else
                     {
-                        global_table_pos[2] = atoi(temp[0].c_str());
+                        global_table_pos[2] = atol(temp[0].c_str());
                     }
                 }
                 else {
                     std::cout << "DICOM.lGlobalTablePosTra not found" << std::endl;
                     global_table_pos[2] = 0;
-                }                                        
+                }
             }
             //Get some parameters - protocol name
             {


### PR DESCRIPTION
Acquisition's position is relative to the table, which may be offset. This commit parses DICOM.lGlobalTablePosSag, DICOM.lGlobalTablePosCor, and DICOM.lGlobalTablePosTra from the buffer, and adds it to the acquisition's position. 

Prior to this change, the table offset is 'thrown out' by siemens_to_ismrmrd.