### PR TITLE
Storing the last 8 lines of aushIceProgramPara into expanded array

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1045,6 +1045,15 @@ getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell
     ismrmrd_acq.user_float()[6] = scanhead.aushIceProgramPara[14];
     ismrmrd_acq.user_float()[7] = scanhead.aushIceProgramPara[15];
 
+    ismrmrd_acq.user_float()[8] = scanhead.aushIceProgramPara[16];
+    ismrmrd_acq.user_float()[9] = scanhead.aushIceProgramPara[17];
+    ismrmrd_acq.user_float()[10] = scanhead.aushIceProgramPara[18];
+    ismrmrd_acq.user_float()[11] = scanhead.aushIceProgramPara[19];
+    ismrmrd_acq.user_float()[12] = scanhead.aushIceProgramPara[20];
+    ismrmrd_acq.user_float()[13] = scanhead.aushIceProgramPara[21];
+    ismrmrd_acq.user_float()[14] = scanhead.aushIceProgramPara[22];
+    ismrmrd_acq.user_float()[15] = scanhead.aushIceProgramPara[23];
+
     if ((scanhead.aulEvalInfoMask[0] & (1ULL << 25))) ismrmrd_acq.setFlag(ISMRMRD::ISMRMRD_ACQ_IS_NOISE_MEASUREMENT);
     if ((scanhead.aulEvalInfoMask[0] & (1ULL << 28))) ismrmrd_acq.setFlag(ISMRMRD::ISMRMRD_ACQ_FIRST_IN_SLICE);
     if ((scanhead.aulEvalInfoMask[0] & (1ULL << 29))) ismrmrd_acq.setFlag(ISMRMRD::ISMRMRD_ACQ_LAST_IN_SLICE);


### PR DESCRIPTION
Dear ISMRMRD,

The Siemens VD software version allows for 24 arrays of custom user defined data of datatype uint16_t (see line 141 in /siemens_to_ismrmrd/siemensraw.h). During the conversion of the raw Siemens data file to the ISMRMRD format, these data arrays get stored either as int32_t or float (see lines 1029 to 1046 in /siemens_to_ismrmrd/main.cpp). However, only the first 16 arrays are stored (the first 8 as int32_t and the second 8 as float); the last 8 arrays of data are not stored.

If what I have described is correct, I propose to store these last 8 arrays of data as float's in the ISMRMRD file. I have hopefully made all the required changes to both the ismrmrd and siemens_to_ismrmrd repositories, and request that you pull these changes. Our group stores peripheral monitoring unit data in these last 8 arrays, and have tested that these changes do successfully write this data to the ISMRMRD file, which was then read in by both Matlab and Python. I can provide Siemens raw data files with this data if you require.

Regards,
Chris Huynh