### PR TITLE
Read multiple flip angles in siemens_parameter_map

### DIFF
--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xml
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xml
@@ -25,6 +25,7 @@
         <p><s>MEAS.sRXSPEC.alDwellTime</s>                                      <d>siemens.MEAS.sRXSPEC.alDwellTime</d></p>
         <p><s>MEAS.alTR</s>                                                     <d>siemens.MEAS.alTR</d></p>
         <p><s>MEAS.alTE</s>                                                     <d>siemens.MEAS.alTE</d></p>
+        <p><s>MEAS.adFlipAngleDegree</s>                                        <d>siemens.MEAS.adFlipAngleDegree</d></p>
         <p><s>MEAS.lContrasts</s>                                               <d>siemens.MEAS.lContrasts</d></p>
         <p><s>MEAS.alTI</s>                                                     <d>siemens.MEAS.alTI</d></p>
         <p><s>MEAS.sSliceArray.asSlice.0.dReadoutFOV</s>                        <d>siemens.MEAS.sSliceArray.asSlice.s0.dReadoutFOV</d></p>
@@ -98,7 +99,6 @@
         <p><s>DICOM.Modality</s>                                                <d>siemens.DICOM.Modality</d></p>
         <p><s>DICOM.tScanningSequence</s>                                       <d>siemens.DICOM.tScanningSequence</d></p>
         <p><s>DICOM.tMRAcquisitionType</s>                                      <d>siemens.DICOM.tMRAcquisitionType</d></p>
-        <p><s>DICOM.adFlipAngleDegree</s>                                       <d>siemens.DICOM.adFlipAngleDegree</d></p>
         <p><s>DICOM.DeviceSerialNumber</s>                                      <d>siemens.DICOM.DeviceSerialNumber</d></p>
         <p><s>DICOM.SoftwareVersions</s>                                        <d>siemens.DICOM.SoftwareVersions</d></p>
         <!-- EPI parameters -->

--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
@@ -689,7 +689,7 @@
                         </TI>
                     </xsl:if>
                 </xsl:for-each>
-                <xsl:for-each select="siemens/DICOM/adFlipAngleDegree">
+                <xsl:for-each select="siemens/MEAS/adFlipAngleDegree">
                     <xsl:if test=". &gt; 0">
                         <flipAngle_deg>
                             <xsl:value-of select="."/>


### PR DESCRIPTION
Dear ISMRMRD,

The default way to read the flip angle for siemens is to use the DICOM.adFlipAngleDegree parameter but this field only store the first value of the flip angle when multiple flip angles are used.

I just made a minor modification in order to use the parameter stored in MEAS.adFlipAngleDegree. It should not impact anybody when only one flip angle value is set but give access to the other flip angle value (Useful for example in order to reconstruct a T1map from an MP2RAGE sequence).

Regards,
Aurelien Trotier