### PR TITLE
Read lGlobalTablePosTra parameter

### DIFF
--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xml
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xml
@@ -122,6 +122,7 @@
 
         <!-- user defined parameter -->
         <p><s>MEAS.sProtConsistencyInfo.tBaselineString</s>                     <d>siemens.MEAS.sProtConsistencyInfo.tBaselineString</d></p>
+	<p><s>YAPS.lGlobalTablePosTra</s>                                       <d>siemens.YAPS.lGlobalTablePosTra</d></p>
 
         <!-- Coil information -->
         <p><s>MEAS.sCoilSelectMeas.aRxCoilSelectData.0.asList.0.sCoilElementID.tCoilID</s>                                       <d>siemens.MEAS.asCoilSelectMeas.ID.tCoilID</d></p>

--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xsl
@@ -809,6 +809,15 @@
                     </userParameterLong>
                 </xsl:if>
 
+		<xsl:if test="siemens/YAPS/lGlobalTablePosTra">
+                  <userParameterLong>
+                    <name>GlobalTablePosTra</name>
+                    <value>
+                        <xsl:value-of select="siemens/YAPS/lGlobalTablePosTra" />
+                    </value>
+                  </userParameterLong>
+                </xsl:if>  
+
 		<xsl:for-each select="siemens/MEAS/sWipMemBlock/adFree">
 			<xsl:variable name="CurDouble" select="position()"/>
 			<userParameterDouble>

--- a/parameter_maps/IsmrmrdParameterMap_Siemens_EPI.xsl
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens_EPI.xsl
@@ -598,6 +598,17 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
                 </xsl:if>
             </sequenceParameters>
 
+	    <userParameters>
+		<xsl:if test="siemens/YAPS/lGlobalTablePosTra">
+                  <userParameterLong>
+                    <name>GlobalTablePosTra</name>
+                    <value>
+                        <xsl:value-of select="siemens/YAPS/lGlobalTablePosTra" />
+                    </value>
+                  </userParameterLong>
+                </xsl:if>  
+	    </userParameters>
+
         </ismrmrdHeader>
     </xsl:template>
 


### PR DESCRIPTION

In order to properly export in nifti an ismrmrd dataset (see : https://github.com/aTrotier/ismrmrd_to_nifti)  we need to read this parameters : YAPS.lGlobalTablePosTra
It is stored under userParametersLong under the name 'GlobalTablePosTra'.

**To discuss :**
* An other way can be to correct the calcul of "patient_table_positon" in siemens_to_ismrmrd but it might broke stuff for someone else. However, i suppose it is the good way to manage whole body acquisition with moving table.
* We can allocate a dedicated field in measurementInformation

Aurelien Trotier