### PR TITLE
Multi-meas output file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ endif()
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
-# May need to be enabled for older Windows and RHEL <= 6
-#set(Boost_NO_BOOST_CMAKE ON)
 
 find_package(Boost COMPONENTS system thread program_options filesystem timer REQUIRED)
 find_package(ISMRMRD REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,9 @@ endif()
 # set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(Boost_NO_BOOST_CMAKE ON)
+
+# May need to be enabled for older Windows and RHEL <= 6
+#set(Boost_NO_BOOST_CMAKE ON)
 
 find_package(Boost COMPONENTS system thread program_options filesystem timer REQUIRED)
 find_package(ISMRMRD REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,8 @@ RUN cd /opt/code && \
 
 # siemens_to_ismrmrd converter
 RUN cd /opt/code && \
-    git clone https://github.com/ismrmrd/siemens_to_ismrmrd.git
-
-COPY main.cpp /opt/code/siemens_to_ismrmrd/
-
-RUN cd /opt/code/siemens_to_ismrmrd && \
+    git clone https://github.com/ismrmrd/siemens_to_ismrmrd.git && \
+    cd siemens_to_ismrmrd && \
     mkdir build && \
     cd build && \
     cmake ../ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:latest as ismrmrd_base
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Chicago
+
+RUN apt-get update && apt-get install -y git cmake g++ libhdf5-dev libxml2-dev libxslt1-dev libboost-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-timer-dev libboost-program-options-dev
+
+RUN  mkdir -p /opt/code
+
+# ISMRMRD library
+RUN cd /opt/code && \
+    git clone https://github.com/ismrmrd/ismrmrd.git && \
+    cd ismrmrd && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make -j $(nproc) && \
+    make install
+
+# siemens_to_ismrmrd converter
+RUN cd /opt/code && \
+    git clone https://github.com/ismrmrd/siemens_to_ismrmrd.git
+
+COPY main.cpp /opt/code/siemens_to_ismrmrd/
+
+RUN cd /opt/code/siemens_to_ismrmrd && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make -j $(nproc) && \
+    make install
+
+# Create archive of ISMRMRD libraries (including symlinks) for second stage
+RUN cd /usr/local/lib && tar -czvf libismrmrd.tar.gz libismrmrd*
+
+# ----- Start another clean build without all of the build dependencies of siemens_to_ismrmrd -----
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends libxslt1.1 libhdf5-103 && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy siemens_to_ismrmrd from last stage and re-add necessary dependencies
+COPY --from=ismrmrd_base /usr/local/bin/siemens_to_ismrmrd  /usr/local/bin/siemens_to_ismrmrd
+COPY --from=ismrmrd_base /usr/local/lib/libismrmrd.tar.gz   /usr/local/lib/
+RUN cd /usr/local/lib && tar -zxvf libismrmrd.tar.gz && rm libismrmrd.tar.gz && ldconfig

--- a/README.mkd
+++ b/README.mkd
@@ -95,19 +95,21 @@ $ siemens_to_ismrmrd -h
 will result in listing all allowed options:
 ```sh
 Allowed options:
-  -h [ --help ]         Produce HELP message
-  -f [ --file ]         <SIEMENS dat file>
-  -z [ --measNum ]      <Measurement number>
-  -m [ --pMap ]         <Parameter map XML>
-  -x [ --pMapStyle ]    <Parameter stylesheet XSL>
-  --user-map            <Provide a parameter map XML file>
-  --user-stylesheet     <Provide a parameter stylesheet XSL file>
-  -o [ --output ]       <HDF5 output file>
-  -g [ --outputGroup ]  <HDF5 output group>
-  -l [ --list ]         <List embedded files>
-  -e [ --extract ]      <Extract embedded file>
-  -X [ --debug ]        <Debug XML flag>
-  -F [ --flashPatRef ]  <FLASH PAT REF flag>
+  -h [ --help ]           Produce HELP message
+  -f [ --file ]           <SIEMENS dat file>
+  -z [ --measNum ]        <Measurement number>
+  -Z [ --allMeas ]        <All measurements flag>
+  -M [ --multiMeasFile ]  <Multiple measurements in single file flag>
+  -m [ --pMap ]           <Parameter map XML>
+  -x [ --pMapStyle ]      <Parameter stylesheet XSL>
+  --user-map              <Provide a parameter map XML file>
+  --user-stylesheet       <Provide a parameter stylesheet XSL file>
+  -o [ --output ]         <HDF5 output file>
+  -g [ --outputGroup ]    <HDF5 output group>
+  -l [ --list ]           <List embedded files>
+  -e [ --extract ]        <Extract embedded file>
+  -X [ --debug ]          <Debug XML flag>
+  -F [ --flashPatRef ]    <FLASH PAT REF flag>
 ```
 ***
 
@@ -115,10 +117,20 @@ Allowed options:
 There are three different types of files that have important role in the process of conversion, and that the user should specify:
 
 - **Siemens dat file**:
-    
-    This is the file that is being converted. The user should supply it using the option **-f**. Siemens dat file can be a VB file of a VD file. In case of VD file that contains multiple measurements, the user can specify which measurement to convert by using the option **-z**. The default value for the option **z** is 1. 
-    
-    In this example, the user is converting second measurement from the *meas_MID00832.dat* file and storing the result in the *resulting_file.h5* file
+
+    This is the file that is being converted. The user must supply it using the option **-f**. Siemens dat file can be a Numaris/4 VB/VD/VE or Numaris/X file. In case of a file that contains multiple measurements, all measurements can be exported using the **-Z** option (default off) into separate files appended by the measurement number. In this example, multi-measurement file *meas_MID00832.dat* file has 2 measurements and two ouput files *resulting_file_1.h5* and *resulting_file_2.h5* are created:
+
+    ```sh
+    $ siemens_to_ismrmrd -f meas_MID00832.dat -o resulting_file.h5 -Z
+    ```
+
+    The "all measurements" **-Z** can be combined with the **-M** to create a multi-measurement output file where different measurements are stored in separate groups. In this example, multi-measurement file *meas_MID00832.dat* file has 2 measurements, stored in HDF5 groups *dataset_1* and *dataset_2* respectively in ouput file *resulting_file.h5*:
+
+    ```sh
+    $ siemens_to_ismrmrd -f meas_MID00832.dat -o resulting_file.h5 -Z -M
+    ```
+
+    A single measurement can be specified using the option **-z** (default value 1). Primary measurement data is usually stored as the last measurement, with earlier measurements being dependencies. In this example, the second measurement from the *meas_MID00832.dat* file is converted and stored in the *resulting_file.h5* file:
 
     ```sh
     $ siemens_to_ismrmrd -f meas_MID00832.dat -o resulting_file.h5 -z 2
@@ -169,9 +181,13 @@ There are three different ways of providing XML and XSL files to the converter:
     ```sh
     $ siemens_to_ismrmrd -f meas_MID00832.dat -o resulting_file.h5
     ```
-    Default XML file for the VB scan is: **IsmrmrdParameterMap_Siemens_VB17.xml**.  
-    Default XML file for the VD scan is: **IsmrmrdParameterMap_Siemens.xml**.  
-    Default XSL file is: **IsmrmrdParameterMap_Siemens.xsl**.
+    Default XML file for Numaris/4 (VB) is: **IsmrmrdParameterMap_Siemens_VB17.xml**.  
+
+    Default XML file for Numaris/4 (VD+) and Numaris/X is: **IsmrmrdParameterMap_Siemens.xml**.  
+
+    Default XSL file for Numaris/4 is: **IsmrmrdParameterMap_Siemens.xsl**.  
+    
+    Default XSL file for Numaris/X is: **IsmrmrdParameterMap_Siemens_NX.xsl**.
 
 2. The user can choose to use XML and XSL files from the list of embedded files. 
 The files should be supplied using options **-m** and **-x**.
@@ -180,16 +196,21 @@ The files should be supplied using options **-m** and **-x**.
     $ siemens_to_ismrmrd -f meas_MID00832.dat -m IsmrmrdParameterMap_Siemens.xml -x IsmrmrdParameterMap_Siemens.xsl -o result.h5
     ```
 
-3. The user can choose to extract embedded files from the convertor (option **-e**)
+3. The user can choose to provide custom XML and/or XSL files using the **--user-map** and **--user-stylesheet** options respectively:
 
     ```sh
-    $ siemens_to_ismrmrd -e IsmrmrdParameterMap_Siemens.xml
-    $ siemens_to_ismrmrd -e IsmrmrdParameterMap_Siemens.xsl
+    $ siemens_to_ismrmrd -f meas_MID00832.dat --user-map IsmrmrdParameterMap_Siemens_modified.xml --user-stylesheet IsmrmrdParameterMap_Siemens_modified.xsl -o result.h5
     ```
 
-    to modify them and to supply modified files (options **--user-map** and **--user-stylesheet**)
-  
-    ```sh
-    $ siemens_to_ismrmrd -f .meas_MID00832.dat --user-map IsmrmrdParameterMap_Siemens_modified.xml --user-stylesheet IsmrmrdParameterMap_Siemens_modified.xsl -o result.h5
-    ```
+For multi-measurement files, if only a single XML/XSL is provided, it is used for all measurements.  A list of different XML/XSL files can also be specified for each measurement. A blank value can be used to use the default file (as above in point 1).  In this example, multi-measurement file *meas_MID00832.dat* file has 2 measurements, with *IsmrmrdParameterMap_Siemens.xml* used for both measurements, *IsmrmrdParameterMap_Siemens.xsl* (default) for the first measurement, and *IsmrmrdParameterMap_Siemens_modified* for the second measurement:
 
+```sh
+$ siemens_to_ismrmrd -f meas_MID00832.dat -m IsmrmrdParameterMap_Siemens.xml --user-stylesheet ",IsmrmrdParameterMap_Siemens_modified.xsl" -o result.h5
+```
+
+The embedded files can be extracted from the convertor using option **-e**:
+
+```sh
+$ siemens_to_ismrmrd -e IsmrmrdParameterMap_Siemens.xml
+$ siemens_to_ismrmrd -e IsmrmrdParameterMap_Siemens.xsl
+```

--- a/main.cpp
+++ b/main.cpp
@@ -72,7 +72,7 @@ std::vector<ISMRMRD::Waveform> readSyncdata(std::ifstream &siemens_dat, bool VBF
                                             uint32_t dma_length, sScanHeader scanheader, ISMRMRD::IsmrmrdHeader &header,
                                             long scan_counter);
 
-std::string getparammap_file_content(const std::string &parammap_file, const std::string &usermap_file, bool VBFILE);
+std::string get_file_content(const std::string &embed_file, const std::string &user_file, const std::string &default_file, std::string &actual_file, const bool all_measurements, const unsigned int currentMeas);
 
 std::vector<MrParcRaidFileEntry>
 readParcFileEntries(std::ifstream &siemens_dat, const MrParcRaidFileHeader &ParcRaidHead, bool VBFILE);
@@ -433,6 +433,7 @@ int main(int argc, char* argv[]) {
     bool header_only = false;
     bool append_buffers = false;
     bool all_measurements = false;
+    bool multi_meas_file = false;
 
     bool list = false;
     std::string to_extract;
@@ -446,6 +447,7 @@ int main(int argc, char* argv[]) {
         ("file,f", po::value<std::string>(&siemens_dat_filename), "<SIEMENS dat file>")
         ("measNum,z", po::value<unsigned int>(&measurement_number)->default_value(1), "<Measurement number>")
         ("allMeas,Z", po::value<bool>(&all_measurements)->implicit_value(true), "<All measurements flag>")
+        ("multiMeasFile,M", po::value<bool>(&multi_meas_file)->implicit_value(true), "<Multiple measurements in single output file flag>")
         ("pMap,m", po::value<std::string>(&parammap_file), "<Parameter map XML file>")
         ("pMapStyle,x", po::value<std::string>(&parammap_xsl), "<Parameter stylesheet XSL file>")
         ("user-map", po::value<std::string>(&usermap_file), "<Provide a parameter map XML file>")
@@ -471,6 +473,7 @@ int main(int argc, char* argv[]) {
         ("file,f", "<SIEMENS dat file>")
         ("measNum,z", "<Measurement number>")
         ("allMeas,Z", "<All measurements flag>")
+        ("multiMeasFile,M", "<Multiple measurements in single file flag>")
         ("pMap,m", "<Parameter map XML>")
         ("pMapStyle,x", "<Parameter stylesheet XSL>")
         ("user-map", "<Provide a parameter map XML file>")
@@ -585,6 +588,7 @@ int main(int argc, char* argv[]) {
 
     // Loop through all measurements in multi-raid
     std::string ismrmrd_file_orig = ismrmrd_file;
+    std::string ismrmrd_group_orig = ismrmrd_group;
     unsigned int firstMeas, lastMeas;
 
     if (all_measurements)
@@ -603,23 +607,33 @@ int main(int argc, char* argv[]) {
 
         if (all_measurements)
         {
-            // Add the measurement number as a suffix to the filename, excluding the file extension
-            std::vector<std::string> v;
-            boost::algorithm::split(v, ismrmrd_file_orig, boost::is_any_of("."));
-
-            if (v.size() > 1)
+            if (multi_meas_file)
             {
-                std::stringstream ss;
-                ss << v.at(v.size()-2) << "_" << currentMeas;
-                v.at(v.size()-2) = ss.str();
-                ismrmrd_file = boost::algorithm::join(v, ".");
+                // Add the measurement number as a suffix to the group name
+                ismrmrd_group = ismrmrd_group_orig;
+                ismrmrd_group.append("_");
+                ismrmrd_group.append(std::to_string(currentMeas));
             }
             else
             {
-                // No file extension found
-                std::stringstream ss;
-                ss << ismrmrd_file_orig << "_" << currentMeas;
-                ismrmrd_file = ss.str();
+                // Add the measurement number as a suffix to the filename, excluding the file extension
+                std::vector<std::string> v;
+                boost::algorithm::split(v, ismrmrd_file_orig, boost::is_any_of("."));
+
+                if (v.size() > 1)
+                {
+                    std::stringstream ss;
+                    ss << v.at(v.size()-2) << "_" << currentMeas;
+                    v.at(v.size()-2) = ss.str();
+                    ismrmrd_file = boost::algorithm::join(v, ".");
+                }
+                else
+                {
+                    // No file extension found
+                    std::stringstream ss;
+                    ss << ismrmrd_file_orig << "_" << currentMeas;
+                    ismrmrd_file = ss.str();
+                }
             }
 
             // Reset file position
@@ -633,18 +647,16 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        std::cout << "------------------------------------------------" << std::endl;
+        std::cout << "-----------------------------------------------------------------" << std::endl;
         if (all_measurements)
         {
-            std::cout << "Converting measurement " << currentMeas << "/" << lastMeas << " into file " << ismrmrd_file << std::endl;
+            std::cout << "Converting measurement " << currentMeas << "/" << lastMeas << " into file " << ismrmrd_file << " in group " << ismrmrd_group << std::endl;
         }
         else
         {
-            std::cout << "Converting measurement " << currentMeas << " into file " << ismrmrd_file << std::endl;
+            std::cout << "Converting measurement " << currentMeas << " into file " << ismrmrd_file << " in group " << ismrmrd_group << std::endl;
         }
-        std::cout << "------------------------------------------------" << std::endl;
-
-
+        std::cout << "-----------------------------------------------------------------" << std::endl;
 
         if (!VBFILE && measurement_number > ParcRaidHead.count_) {
             std::cout << "The file you are trying to convert has only " << ParcRaidHead.count_ << " measurements."
@@ -660,7 +672,16 @@ int main(int argc, char* argv[]) {
             return -1;
         }
 
-        std::string parammap_file_content = getparammap_file_content(parammap_file, usermap_file, VBFILE);
+        // Parameter map
+        std::string default_parammap;
+        if (VBFILE) {
+            default_parammap = "IsmrmrdParameterMap_Siemens_VB17.xml";
+        } else {
+            default_parammap = "IsmrmrdParameterMap_Siemens.xml";
+        }
+        std::string parammap_actual_file;
+        std::string parammap_file_content = get_file_content(parammap_file, usermap_file, default_parammap, parammap_actual_file, all_measurements, currentMeas);
+        std::cout << "Using parameter map: " << parammap_actual_file << std::endl;
 
         std::cout << "This file contains " << ParcRaidHead.count_ << " measurement(s)." << std::endl;
 
@@ -737,45 +758,17 @@ int main(int argc, char* argv[]) {
             o.write(xml_config.c_str(), xml_config.size());
         }
 
-        std::string parammap_xsl_content;
-        if (parammap_xsl.length() == 0) {
-            // If the user did not specify any stylesheet
-            if (usermap_xsl.length() == 0) {
-                if (isNX)
-                {
-                    parammap_xsl_content = load_embedded("IsmrmrdParameterMap_Siemens_NX.xsl");
-                    std::cout << "Parameter XSL stylesheet is: IsmrmrdParameterMap_Siemens_NX.xsl" << std::endl;
-                }
-                else
-                {
-                    parammap_xsl_content = load_embedded("IsmrmrdParameterMap_Siemens.xsl");
-                    std::cout << "Parameter XSL stylesheet is: IsmrmrdParameterMap_Siemens.xsl" << std::endl;
-                }
-            }
-            // If the user specified only a user-supplied stylesheet
-            else {
-                std::ifstream f(usermap_xsl.c_str());
-                if (!f) {
-                    std::cerr << "Parameter XSL stylesheet: " << usermap_xsl << " does not exist." << std::endl;
-                    return -1;
-                }
-                std::cout << "Parameter XSL stylesheet is: " << usermap_xsl << std::endl;
-                std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-                parammap_xsl_content = str_f;
-            }
+        // Parameter style-sheet
+        std::string default_parammap_xsl;
+        if (isNX) {
+            default_parammap_xsl = "IsmrmrdParameterMap_Siemens_NX.xsl";
+        } else {
+            default_parammap_xsl = "IsmrmrdParameterMap_Siemens.xsl";
         }
-        else {
-            // If the user specified both an embedded and user-supplied stylesheet
-            if (usermap_xsl.length() > 0) {
-                std::cerr << "Cannot specify a user-supplied parameter map XSL stylesheet AND embedded stylesheet"
-                    << std::endl;
-                return -1;
-            }
+        std::string parammap_xsl_actual_file;
+        std::string parammap_xsl_content = get_file_content(parammap_xsl, usermap_xsl, default_parammap_xsl, parammap_xsl_actual_file, all_measurements, currentMeas);
+        std::cout << "Using parameter XSL: " << parammap_xsl_actual_file << std::endl;
 
-            // The user specified an embedded stylesheet only
-            parammap_xsl_content = load_embedded(parammap_xsl);
-            std::cout << "Parameter XSL stylesheet is: " << parammap_xsl << std::endl;
-        }
 
         ISMRMRD::IsmrmrdHeader header;
         {
@@ -2029,74 +2022,78 @@ readParcFileEntries(std::ifstream &siemens_dat, const MrParcRaidFileHeader &Parc
     return ParcFileEntries;
 }
 
-std::string getparammap_file_content(const std::string &parammap_file, const std::string &usermap_file, bool VBFILE) {
-    std::string parammap_file_content;
-    if (VBFILE) {
-        if (parammap_file.length() == 0) {
-            // If the user did not specify any parameter map file
-            if (usermap_file.length() == 0) {
-                parammap_file_content = load_embedded("IsmrmrdParameterMap_Siemens_VB17.xml");
-                std::cout << "Parameter map file is: IsmrmrdParameterMap_Siemens_VB17.xml" << std::endl;
-            }
-                // If the user specified only a user-supplied parameter map file
-            else {
-                std::ifstream f(usermap_file.c_str());
-                if (!f) {
+std::string get_file_content(const std::string &embed_file, const std::string &user_file, const std::string &default_file, std::string &actual_file, const bool all_measurements, const unsigned int currentMeas) {
+    // Load parameter map or stylesheet contents
+
+    std::string file_content;
+    if ((embed_file.length() > 0) && (user_file.length() > 0)) {
+        // Both an embedded and user-supplied file
+        std::stringstream sstream;
+        sstream << "Cannot specify both user (" << user_file << ") and embedded (" << embed_file << ") files";
+        throw std::runtime_error(sstream.str());
+    } else if ((embed_file.length() == 0) && (user_file.length() == 0)) {
+        // Neither embedded nor user-supplied file -- use default file
+        actual_file = default_file;
+        file_content = load_embedded(actual_file);
+    } else if (user_file.length() > 0) {
+        // User-specified file
+        if (all_measurements)
+        {
+            // Allow different files for each measurement, delimited by commas
+            std::vector<std::string> vs_user_files;
+            boost::algorithm::split(vs_user_files, user_file, boost::is_any_of(","));
+            if (vs_user_files.size() == 1) {
+                actual_file = user_file;
+            } else {
+                if (currentMeas-1 < vs_user_files.size()) {
+                    actual_file = vs_user_files.at(currentMeas-1);
+                    if (actual_file.length() == 0) {
+                        actual_file = default_file;
+                    }
+                } else {
                     std::stringstream sstream;
-                    sstream << "Parameter map file: " << usermap_file << " does not exist.";
+                    sstream << "all_measurements is true and multiple user files are provided (" << user_file << "), but the current measurement " << currentMeas << " exceeds the number of number of user files";
                     throw std::runtime_error(sstream.str());
-
                 }
-
-                std::cout << "Parameter map file is: " << usermap_file << std::endl;
-                std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-                parammap_file_content = str_f;
             }
         } else {
-            // If the user specified both an embedded and user-supplied parameter map file
-            if (usermap_file.length() > 0) {
-                std::stringstream sstream;
-                sstream << "Cannot specify a user-supplied parameter map XML file AND embedded XML file";
-                throw std::runtime_error(sstream.str());
-
-            }
-            // The user specified an embedded parameter map file only
-            parammap_file_content = load_embedded(parammap_file);
-            std::cout << "Parameter map file is: " << parammap_file << std::endl;
+            actual_file = user_file;
         }
-    } else {
-        if (parammap_file.length() == 0) {
-            // If the user did not specify any parameter map file
-            if (usermap_file.length() == 0) {
-                parammap_file_content = load_embedded("IsmrmrdParameterMap_Siemens.xml");
-                std::cout << "Parameter map file is: IsmrmrdParameterMap_Siemens.xml" << std::endl;
-            }
-                // If the user specified only a user-supplied parameter map file
-            else {
-                std::ifstream f(usermap_file.c_str());
-                if (!f) {
+
+        // Read in file contents
+        std::ifstream f(actual_file.c_str());
+        if (!f) {
+            std::stringstream sstream;
+            sstream << "file: " << actual_file << " does not exist.";
+            throw std::runtime_error(sstream.str());
+        }
+        std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        file_content = str_f;
+    } else if (embed_file.length() > 0) {
+        // Embedded file
+        std::string actual_file;
+        if (all_measurements) {
+            // Allow different files for each measurement, delimited by commas
+            std::vector<std::string> vs_embed_files;
+            boost::algorithm::split(vs_embed_files, embed_file, boost::is_any_of(","));
+            if (vs_embed_files.size() == 1) {
+                actual_file = embed_file;
+            } else {
+                if (currentMeas-1 < vs_embed_files.size())
+                {
+                    actual_file = vs_embed_files.at(currentMeas-1);
+                } else {
                     std::stringstream sstream;
-                    sstream << "Parameter map file: " << usermap_file << " does not exist.";
+                    sstream << "all_measurements is true and multiple embedded files are provided (" << embed_file << "), but the current measurement " << currentMeas << " exceeds the number of number of embedded files";
                     throw std::runtime_error(sstream.str());
-
                 }
-
-                std::cout << "Parameter map file is: " << usermap_file << std::endl;
-                std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-                parammap_file_content = str_f;
             }
         } else {
-            // If the user specified both an embedded and user-supplied parameter map file
-            if (usermap_file.length() > 0) {
-                std::stringstream sstream;
-                sstream << "Cannot specify a user-supplied parameter map XML file AND embedded XML file";
-                throw std::runtime_error(sstream.str());
-
-            }
-            // The user specified an embedded parameter map file only
-            parammap_file_content = load_embedded(parammap_file);
-            std::cout << "Parameter map file is: " << parammap_file << std::endl;
+            actual_file = embed_file;
         }
+
+        // Read in file contents
+        file_content = load_embedded(actual_file);
     }
-    return parammap_file_content;
+    return file_content;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -396,6 +396,22 @@ std::string load_embedded(std::string name) {
     return contents;
 }
 
+std::string load_file(std::string file_name) {
+    // Read in file contents
+    std::string contents;
+
+    std::ifstream f(file_name.c_str());
+    if (!f) {
+        std::stringstream sstream;
+        sstream << "file: " << file_name << " does not exist.";
+        throw std::runtime_error(sstream.str());
+    }
+    std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    contents = str_f;
+
+    return contents;
+}
+
 
 std::string ws2s(const std::wstring &wstr) {
     std::string ret(wstr.size(), '0');
@@ -2044,11 +2060,15 @@ std::string get_file_content(const std::string &embed_file, const std::string &u
             boost::algorithm::split(vs_user_files, user_file, boost::is_any_of(","));
             if (vs_user_files.size() == 1) {
                 actual_file = user_file;
+                file_content = load_file(actual_file);
             } else {
                 if (currentMeas-1 < vs_user_files.size()) {
                     actual_file = vs_user_files.at(currentMeas-1);
                     if (actual_file.length() == 0) {
                         actual_file = default_file;
+                        file_content = load_embedded(actual_file);
+                    } else {
+                        file_content = load_file(actual_file);
                     }
                 } else {
                     std::stringstream sstream;
@@ -2058,17 +2078,8 @@ std::string get_file_content(const std::string &embed_file, const std::string &u
             }
         } else {
             actual_file = user_file;
+            file_content = load_file(actual_file);
         }
-
-        // Read in file contents
-        std::ifstream f(actual_file.c_str());
-        if (!f) {
-            std::stringstream sstream;
-            sstream << "file: " << actual_file << " does not exist.";
-            throw std::runtime_error(sstream.str());
-        }
-        std::string str_f((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-        file_content = str_f;
     } else if (embed_file.length() > 0) {
         // Embedded file
         std::string actual_file;


### PR DESCRIPTION
Add non-default option "-M" (--multiMeasFile) to create a multi-measurement ISMRMRD HDF5 output file. Measurements are stored in sequentially numbered groups. Documentation updated and Dockerfile added as well.