### PR TITLE
Change acq.pos behaviour to be relative to iso

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1055,9 +1055,10 @@ getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell
     }
     // std::cout << "ismrmrd_acq.sample_time_us(): " << ismrmrd_acq.sample_time_us() << std::endl;
 
-    ismrmrd_acq.position()[0] = scanhead.sSliceData.sSlicePosVec.flSag + (float) (global_table_pos[0]);
-    ismrmrd_acq.position()[1] = scanhead.sSliceData.sSlicePosVec.flCor + (float) (global_table_pos[1]);
-    ismrmrd_acq.position()[2] = scanhead.sSliceData.sSlicePosVec.flTra + (float) (global_table_pos[2]);
+    // Position vector to reflect relative to iso (& match IceGadgetron)
+    ismrmrd_acq.position()[0] = scanhead.sSliceData.sSlicePosVec.flSag;// + (float) (global_table_pos[0]);
+    ismrmrd_acq.position()[1] = scanhead.sSliceData.sSlicePosVec.flCor;// + (float) (global_table_pos[1]);
+    ismrmrd_acq.position()[2] = scanhead.sSliceData.sSlicePosVec.flTra;// + (float) (global_table_pos[2]);
 
     // Convert Siemens quaternions to direction cosines.
     // In the Siemens convention the quaternion corresponds to a rotation matrix with columns P R S

--- a/main.cpp
+++ b/main.cpp
@@ -1080,9 +1080,10 @@ getAcquisition(bool flash_pat_ref_scan, const Trajectory &trajectory, long dwell
     //std::cout << "slice_dir    = [" << ismrmrd_acq.slice_dir()[0] << " " << ismrmrd_acq.slice_dir()[1] << " " << ismrmrd_acq.slice_dir()[2] << "]" << std::endl;
     //std::cout << "--------------------------------------------------------" << std::endl;
 
-    ismrmrd_acq.patient_table_position()[0] = (float) scanhead.lPTABPosX;
-    ismrmrd_acq.patient_table_position()[1] = (float) scanhead.lPTABPosY;
-    ismrmrd_acq.patient_table_position()[2] = (float) scanhead.lPTABPosZ;
+    // Reflect a useful value: Table shift from "lasered" positioning
+    ismrmrd_acq.patient_table_position()[0] = (float) (global_table_pos[0]); //(float) scanhead.lPTABPosX;
+    ismrmrd_acq.patient_table_position()[1] = (float) (global_table_pos[1]); //(float) scanhead.lPTABPosY;
+    ismrmrd_acq.patient_table_position()[2] = (float) (global_table_pos[2]); //(float) scanhead.lPTABPosZ;
 
     bool fixedE1E2 = true;
     if ((scanhead.aulEvalInfoMask[0] & (1ULL << 25))) fixedE1E2 = false; // noise


### PR DESCRIPTION
acq.position will be reverted to relative to iso.
acq.patient_table_position will now reflect the "global table pos" - relative to the lasered position at the start of the study. 

disclaimer - I dont know if anyone uses the previous version of acq.patient_table_position but it seems pretty unhelpful to me. 