### PR TITLE
Set default output filename to match base path of input

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -441,7 +441,6 @@ int main(int argc, char* argv[]) {
 
     std::string schema_file_name;
 
-    std::string ismrmrd_file;
     std::string ismrmrd_group;
     std::string date_time = get_date_time_string();
 
@@ -473,7 +472,7 @@ int main(int argc, char* argv[]) {
         ("pMapStyle,x", po::value<std::string>(&parammap_xsl), "<Parameter stylesheet XSL file>")
         ("user-map", po::value<std::string>(&usermap_file), "<Provide a parameter map XML file>")
         ("user-stylesheet", po::value<std::string>(&usermap_xsl), "<Provide a parameter stylesheet XSL file>")
-        ("output,o", po::value<std::string>(&ismrmrd_file)->default_value(""), "<ISMRMRD output file>")
+        ("output,o", po::value<std::string>(), "<ISMRMRD output file (defaults to the input file name, with .mrd extension)>")
         ("outputGroup,g", po::value<std::string>(&ismrmrd_group)->default_value("dataset"),
             "<ISMRMRD output group>")
             ("list,l", po::value<bool>(&list)->implicit_value(true), "<List embedded files>")
@@ -594,11 +593,14 @@ int main(int argc, char* argv[]) {
     }
     std::cout << "Siemens file is: " << siemens_dat_filename << std::endl;
 
-    if (ismrmrd_file.empty())
+    std::string ismrmrd_file;
+    if (!vm.count("output"))
     {
         boost::filesystem::path siemens_dat_path(siemens_dat_filename);
         ismrmrd_file = siemens_dat_path.replace_extension(".mrd").string();
         std::cout << "Output file not specified -- using " << ismrmrd_file << std::endl;
+    } else {
+        ismrmrd_file = vm["output"].as<std::string>();
     }
 
     std::string schema_file_name_content = load_embedded("ismrmrd.xsd");

--- a/main.cpp
+++ b/main.cpp
@@ -470,7 +470,7 @@ int main(int argc, char* argv[]) {
         ("pMapStyle,x", po::value<std::string>(&parammap_xsl), "<Parameter stylesheet XSL file>")
         ("user-map", po::value<std::string>(&usermap_file), "<Provide a parameter map XML file>")
         ("user-stylesheet", po::value<std::string>(&usermap_xsl), "<Provide a parameter stylesheet XSL file>")
-        ("output,o", po::value<std::string>(&ismrmrd_file)->default_value("output.h5"), "<ISMRMRD output file>")
+        ("output,o", po::value<std::string>(&ismrmrd_file)->default_value(""), "<ISMRMRD output file>")
         ("outputGroup,g", po::value<std::string>(&ismrmrd_group)->default_value("dataset"),
             "<ISMRMRD output group>")
             ("list,l", po::value<bool>(&list)->implicit_value(true), "<List embedded files>")
@@ -578,6 +578,27 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     std::cout << "Siemens file is: " << siemens_dat_filename << std::endl;
+
+    if (ismrmrd_file.empty())
+    {
+        // Use the intput filename, but with an h5 extension
+        std::vector<std::string> v;
+        boost::algorithm::split(v, siemens_dat_filename, boost::is_any_of("."));
+
+        if ((v.size() > 1) && (v.back().compare("h5") != 0))
+        {
+            v.back() = std::string("h5");
+            ismrmrd_file = boost::algorithm::join(v, ".");
+        }
+        else
+        {
+            // No file extension found
+            std::stringstream ss;
+            ss << siemens_dat_filename << "_ismrmrd";
+            ismrmrd_file = ss.str();
+        }
+        std::cout << "Output file not specified -- using " << ismrmrd_file << std::endl;
+    }
 
     std::string schema_file_name_content = load_embedded("ismrmrd.xsd");
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
+#include <boost/filesystem.hpp>
 #include <boost/locale/encoding_utf.hpp>
 using boost::locale::conv::utf_to_utf;
 
@@ -581,22 +582,8 @@ int main(int argc, char* argv[]) {
 
     if (ismrmrd_file.empty())
     {
-        // Use the intput filename, but with an h5 extension
-        std::vector<std::string> v;
-        boost::algorithm::split(v, siemens_dat_filename, boost::is_any_of("."));
-
-        if ((v.size() > 1) && (v.back().compare("h5") != 0))
-        {
-            v.back() = std::string("h5");
-            ismrmrd_file = boost::algorithm::join(v, ".");
-        }
-        else
-        {
-            // No file extension found
-            std::stringstream ss;
-            ss << siemens_dat_filename << "_ismrmrd";
-            ismrmrd_file = ss.str();
-        }
+        boost::filesystem::path siemens_dat_path(siemens_dat_filename);
+        ismrmrd_file = siemens_dat_path.replace_extension(".mrd").string();
         std::cout << "Output file not specified -- using " << ismrmrd_file << std::endl;
     }
 


### PR DESCRIPTION
This sets a default output filename to match the input name so that it's easier to use.

@hansenms If you have a cleaner way of implementing, please suggest it.