### PR TITLE
Changed environmental variable setting for the latest version of ismrmrd.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -46,11 +46,13 @@ $ cmake ..
 $ make
 $ sudo make install
 ```
-#### Set the ISMRMRD environmental variable:
+#### Set the ISMRMRD shared library path:
+For default installation path of ISMRMRD:
 ```sh
-$ echo "export ISMRMRD_HOME=/usr/local/ismrmrd" >> $HOME/.bash_profile
+$ echo "export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}" >> $HOME/.bash_profile
 $ source $HOME/.bash_profile
 ```
+For customized installation path of ISMRMRD, replace `/usr/local/lib` to the directory where file `libismrmrd.so` locates.
 ### Installing siemens_to_ismrmrd:
 
 #### Unpack the siemens_to_ismrmrd.tar.gz file or clone siemens_to_ismrmrd from the repository:

--- a/README.mkd
+++ b/README.mkd
@@ -47,12 +47,16 @@ $ make
 $ sudo make install
 ```
 #### Set the ISMRMRD shared library path:
-For default installation path of ISMRMRD:
+For the default installation path of ISMRMRD, add the following lines to `$HOME/.bashrc`:
 ```sh
-$ echo "export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}" >> $HOME/.bash_profile
-$ source $HOME/.bash_profile
+$ ISMRMRD_HOME=/usr/local/
+$ PATH=$PATH:$ISMRMRD_HOME/bin
+$ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ISMRMRD_HOME/lib
 ```
-For customized installation path of ISMRMRD, replace `/usr/local/lib` to the directory where file `libismrmrd.so` locates.
+And then execute the command `source ~/.bashrc`.
+
+For the customized installation path of ISMRMRD, set the user defined directory as `ISMRMRD_HOME`.
+
 ### Installing siemens_to_ismrmrd:
 
 #### Unpack the siemens_to_ismrmrd.tar.gz file or clone siemens_to_ismrmrd from the repository:


### PR DESCRIPTION
The default installation path for the latest version of ISMRMRD is no longer to `/usr/local/ismrmrd`. There is a possibility that the default directory for the shared library file `libismrmrd.so` has not been specified for `LD_LIBRARY_PATH`, especially for the newly installed Linux system.