### PR TITLE
Added dicom FA to Siemens XML

### DIFF
--- a/parameter_maps/IsmrmrdParameterMap_Siemens.xml
+++ b/parameter_maps/IsmrmrdParameterMap_Siemens.xml
@@ -107,6 +107,7 @@
         <p><s>DICOM.tMRAcquisitionType</s>                                      <d>siemens.DICOM.tMRAcquisitionType</d></p>
         <p><s>DICOM.DeviceSerialNumber</s>                                      <d>siemens.DICOM.DeviceSerialNumber</d></p>
         <p><s>DICOM.SoftwareVersions</s>                                        <d>siemens.DICOM.SoftwareVersions</d></p>
+        <p><s>DICOM.adFlipAngleDegree</s>                                       <d>siemens.DICOM.adFlipAngleDegree</d></p>
         <!-- EPI parameters -->
         <p><s>MEAS.sFastImaging.lEPIFactor</s>                                  <d>siemens.MEAS.sFastImaging.lEPIFactor</d></p>
         <p><s>YAPS.lEchoSpacing</s>                                             <d>siemens.YAPS.lEchoSpacing</d></p>


### PR DESCRIPTION
On our NumarisX System (XA61) using [IsmrmrdParameterMap_Siemens_NX.xsl](https://github.com/ismrmrd/siemens_to_ismrmrd/blob/master/parameter_maps/IsmrmrdParameterMap_Siemens_NX.xsl) Paramter Map (default) the flipAngle_deg was not written into the ismrmrd header. The relevant part of the XSL is this:
```
                </xsl:for-each> 
                <xsl:for-each select="siemens/DICOM/adFlipAngleDegree">
                <xsl:if test=". &gt; 0">
                        <flipAngle_deg>
                            <xsl:value-of select="." />
                        </flipAngle_deg>
                    </xsl:if>
                </xsl:for-each>
```

The `siemens/DICOM/adFlipAngleDegree` is not defined in the [Siemens default parameter map](https://github.com/ismrmrd/siemens_to_ismrmrd/blob/master/parameter_maps/IsmrmrdParameterMap_Siemens.xml). 

Is there a specific reason for that or would it make sense to just include it here? In the [VB17 XML file](https://github.com/ismrmrd/siemens_to_ismrmrd/blob/master/parameter_maps/IsmrmrdParameterMap_Siemens_VB17.xml) it is included.