### PR TITLE
fix Dockerfile by adding libpugixml1v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN cd /usr/local/lib && tar -czvf libismrmrd.tar.gz libismrmrd*
 # ----- Start another clean build without all of the build dependencies of siemens_to_ismrmrd -----
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends libxslt1.1 libhdf5-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libxslt1.1 libhdf5-dev libpugixml1v5 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy siemens_to_ismrmrd from last stage and re-add necessary dependencies
 COPY --from=ismrmrd_base /usr/local/bin/siemens_to_ismrmrd  /usr/local/bin/siemens_to_ismrmrd


### PR DESCRIPTION
After building the image and trying to use the library I encounter an error: (step to reproduce)
% docker build -t siemens_to_ismrmrd_image .
% docker run -it siemens_to_ismrmrd_image /bin/bash
root@e8fb57b6c3b9:/# siemens_to_ismrmrd
siemens_to_ismrmrd: error while loading shared libraries: libpugixml.so.1: cannot open shared object file: No such file or directory

I fixed the error by adding libpugixml1v5 in the second stage of the building process. Now running the same code results in:
% docker build -t siemens_to_ismrmrd_image .
% docker run -it siemens_to_ismrmrd_image /bin/bash
root@c5f0bf7c81bb:/# siemens_to_ismrmrd
Missing Siemens DAT filename
Allowed options:
  -h [ --help ]           Produce HELP message
  -v [ --version ]        Prints converter version and ISMRMRD version
  -f [ --file ]           <SIEMENS dat file>
  -z [ --measNum ]        <Measurement number>
  -Z [ --allMeas ]        <All measurements flag>
  -M [ --multiMeasFile ]  <Multiple measurements in single file flag>
  --skipSyncData          <Skip syncdata (PMU) conversion>
  --attachTrajectory      <Attach trajectories using vds design>
  -m [ --pMap ]           <Parameter map XML>
  -x [ --pMapStyle ]      <Parameter stylesheet XSL>
  -o [ --output ]         <ISMRMRD output file>
  -g [ --outputGroup ]    <ISMRMRD output group>
  -l [ --list ]           <List embedded files>
  -e [ --extract ]        <Extract embedded file>
  -X [ --debug ]          <Debug XML flag>
  -F [ --flashPatRef ]    <FLASH PAT REF flag>
  -H [ --headerOnly ]     <HEADER ONLY flag (create xml header only)>
  -B [ --bufferAppend ]   <Append protocol buffers>
  --studyDate             <User can supply study date, in the format of 
                          yyyy-mm-dd>